### PR TITLE
Disable Windows code signing to fix electron-builder symbolic link er…

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
       "public/electron.cjs"
     ],
     "win": {
-      "target": "nsis"
+      "target": "nsis",
+      "sign": false
     },
     "linux": {
       "target": "AppImage"


### PR DESCRIPTION
…rors

- Add 'sign: false' to win build config in package.json
- This bypasses winCodeSign extraction that was failing with symbolic link permission errors
- Should allow .exe installer creation to complete successfully
- Resolves electron-builder getting stuck in retry loop during Windows builds