### PR TITLE
Improve electron-builder configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "cobol-ubereats-emulator",
   "private": true,
   "version": "1.0.0",
+  "description": "A retro 3270 terminal emulator for ordering food, built for COBOL enthusiasts",
+  "author": "Patty's Food Tracker Team",
   "type": "module",
   "main": "public/electron.cjs",
   "homepage": "./",
@@ -94,8 +96,8 @@
     },
     "files": [
       "dist/**/*",
-      "node_modules/**/*",
-      "public/electron.cjs"
+      "public/electron.cjs",
+      "public/assets/**/*"
     ],
     "win": {
       "target": "nsis",


### PR DESCRIPTION
- Add missing description and author fields to fix build warnings
- Clean up files array to remove unnecessary node_modules inclusion
- Include public/assets for icon and other assets
- This should resolve electron-builder warnings and improve build reliability