### PR TITLE
Fix electron-builder configuration for Windows builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,12 +96,11 @@
     },
     "files": [
       "dist/**/*",
-      "public/electron.cjs",
-      "public/assets/**/*"
+      "public/electron.cjs"
     ],
     "win": {
       "target": "nsis",
-      "sign": false
+      "forceCodeSigning": false
     },
     "linux": {
       "target": "AppImage"


### PR DESCRIPTION
- Remove reference to non-existent public/assets directory from files array
- Use forceCodeSigning: false instead of invalid sign: false property
- Configuration now passes validation and starts build process correctly
- Wine would be needed to complete Windows build on Linux, but config is ready for Windows testing