### PR TITLE
Fix electron-builder code signing configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     ],
     "win": {
       "target": "nsis",
-      "forceCodeSigning": false
+      "signAndEditExecutable": false,
+      "verifyUpdateCodeSignature": false
     },
     "linux": {
       "target": "AppImage"


### PR DESCRIPTION
- Replace forceCodeSigning: false with signAndEditExecutable: false and verifyUpdateCodeSignature: false
- This prevents winCodeSign binary downloads that cause symbolic link errors on Windows
- Configuration now properly disables code signing completely
- Build process now reaches NSIS installer creation stage successfully